### PR TITLE
[Patch]: Adding a -t option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ But what if we could just extract these models and generate types instead? Oh...
 
 ### 🔶 Disclaimer
 
-⚠️🚨 I wrote this for a stack based on [nestjs](https://nestjs.com/) for the backend and [react-query](https://react-query.tanstack.com/) for the frontend, so this tool may or may not suit your needs. If you think about another usecase, do not hesitate to drop an issue 🙃.
+🚨 I wrote this for a stack based on [nestjs](https://nestjs.com/) for the backend and [react-query](https://react-query.tanstack.com/) for the frontend, so this tool may or may not suit your needs. If you think about another usecase, do not hesitate to drop an issue 🙃.
 
 ## ⚡ Installation
 
@@ -64,17 +64,23 @@ Knowing this, we can add a script to our package.json:
 ```json
 {
   "scripts": {
-    "api:sync": "generateTypesFromUrl -u https://rhf-mui-nx-sandbox-back.herokuapp.com/-json -o ./src/api/types"
+    "api:sync": "generateTypesFromUrl -u https://rhf-mui-nx-sandbox-back.herokuapp.com/-json -o ./src/api/types [-t]"
   }
 }
 ```
 
 The `generateTypesFromUrl` task takes tree arguments:
 
-| name   | description                                                            | Example         |
-| --- | ---------------------------------------------------------------------- | --------------- |
-| u  | The url of the json exposed by the targeted swagger | <https://rhf-mui-nx-sandbox-back.herokuapp.com/-json> |
-| o  | Where to write our exposed types                  | ./src/api/types           |
+| name | description                                         | Example                                               |
+| ---- | --------------------------------------------------- | ----------------------------------------------------- |
+| u    | The url of the json exposed by the targeted swagger | <https://rhf-mui-nx-sandbox-back.herokuapp.com/-json> |
+| o    | Where to write our exposed types                    | ./src/api/types                                       |
+
+Optionally, you can use `-t` flag if you're using `importsNotUsedAsValues` in your tsconfig compiler options. It will generate imports like so:
+
+```typescript
+import type { ... } from ...
+```
 
 Our task will do a few things using these arguments when called:
 
@@ -94,17 +100,23 @@ We can also generate types from a file:
 ```json
 {
   "scripts": {
-    "api:sync": "generateTypesFromFile -i ./specs/swagger.json -o ./src/api/types"
+    "api:sync": "generateTypesFromFile -i ./specs/swagger.json -o ./src/api/types [-t]"
   }
 }
 ```
 
 The `generateTypesFromUrl` task takes two arguments:
 
-| name   | description                                                            | Example                |
-| --- | ---------------------------------------------------------------------- | ---------------------- |
-| i  | The path of the swagger json file                                      | ./specs/swagger.json |
-| o  | Where to write our exposed types                                       | ./src/api/types        |
+| name | description                       | Example              |
+| ---- | --------------------------------- | -------------------- |
+| i    | The path of the swagger json file | ./specs/swagger.json |
+| o    | Where to write our exposed types  | ./src/api/types      |
+
+Optionally, you can use `-t` flag if you're using `importsNotUsedAsValues` in your tsconfig compiler options. It will generate imports like so:
+
+```typescript
+import type { ... } from ...
+```
 
 Again, our task will do the following:
 
@@ -186,6 +198,16 @@ const json: InputSwaggerJson = await fetchSwaggerJson(
 );
 ```
 
+#### 🌀 readSwaggerJsonFile
+
+This function gets the content of a swagger json file. Typical use:
+
+```typescript
+const json: InputSwaggerJson = await readSwaggerJsonFile(
+  './specs/my-swagger.json',
+);
+```
+
 #### 🌀 validateSchema
 
 This function validates some arbitrary json against the [openapiv3 schema](https://github.com/APIDevTools/openapi-schemas). Typically use:
@@ -201,9 +223,9 @@ const schema: ValidatedOpenaApiSchema = await validateSchema(data);
 This function extracts models from the swagger json and generates typings from them. Typical use:
 
 ```typescript
-const enVarName = 'API_URL';
 const outPath = './src/api/types';
 const schema: ValidatedOpenaApiSchema = { ... };
+const importsNotUsedAsValues = true
 
-await generateTypesDefinitions(envVarName, outPath, schema);
+await generateTypesDefinitions(outPath, schema, importsNotUsedAsValues);
 ```

--- a/README.md
+++ b/README.md
@@ -188,24 +188,38 @@ On top of the cli, this package exposes the following functions:
 
 ### 🔶 Functions
 
-#### 🌀 fetchSwaggerJson
+#### 🌀 generateTypesFromUrl
 
-This function fetches the swagger json using axios. Typical use:
+This function generates types from a swagger exposed online. Typical use:
 
 ```typescript
-const json: InputSwaggerJson = await fetchSwaggerJson(
-  'https://workshop-react-back.herokuapp.com/-json',
-);
+const params = {
+  swaggerJsonUrl: 'https://workshop-react-back.herokuapp.com/-json',
+  outputPath './src/specs',
+  importsNotUsedAsValues: false
+};
+
+const {
+  typesGenerated, // boolean, specifies whether types have been extracted (./api-types.ts file)
+  endpointsCount  // number of endpoints extracted
+}: GenerationResult = await generateTypesFromUrl(params);
 ```
 
-#### 🌀 readSwaggerJsonFile
+#### 🌀 generateTypesFromFile
 
-This function gets the content of a swagger json file. Typical use:
+This function generates types from a swagger json file. Typical use:
 
 ```typescript
-const json: InputSwaggerJson = await readSwaggerJsonFile(
-  './specs/my-swagger.json',
-);
+const params = {
+  inputPath: './src/api/swagger.json',
+  outputPath './src/specs',
+  importsNotUsedAsValues: false
+};
+
+const {
+  typesGenerated, // boolean, specifies whether types have been extracted (./api-types.ts file)
+  endpointsCount  // number of endpoints extracted
+}: GenerationResult = await generateTypesFromFile(params);
 ```
 
 #### 🌀 validateSchema

--- a/src/cli/args/validate-file-arguments.test.ts
+++ b/src/cli/args/validate-file-arguments.test.ts
@@ -30,7 +30,7 @@ describe('validateFileArguments function', () => {
     expect(console.error).toHaveBeenCalledWith('Missing required argument: o');
   });
 
-  it('should return args', async () => {
+  it('should return args and default values', async () => {
     const args = runCommand(
       validateArgumentsPath,
       '-i',
@@ -42,6 +42,42 @@ describe('validateFileArguments function', () => {
     expect(args).toStrictEqual({
       inputPath,
       outputPath,
+      importsNotUsedAsValues: false,
     });
+  });
+
+  it('should return true when passing -t option', async () => {
+    const args = runCommand(
+      validateArgumentsPath,
+      '-i',
+      inputPath,
+      '-o',
+      outputPath,
+      '-t',
+    );
+
+    expect(args).toEqual(
+      expect.objectContaining({
+        importsNotUsedAsValues: true,
+      }),
+    );
+  });
+
+  it('should return true when giving an arbitrary valut to -t option', async () => {
+    const args = runCommand(
+      validateArgumentsPath,
+      '-i',
+      inputPath,
+      '-o',
+      outputPath,
+      '-t',
+      'yolo',
+    );
+
+    expect(args).toEqual(
+      expect.objectContaining({
+        importsNotUsedAsValues: true,
+      }),
+    );
   });
 });

--- a/src/cli/args/validate-file-arguments.ts
+++ b/src/cli/args/validate-file-arguments.ts
@@ -4,15 +4,29 @@ import yargs from 'yargs/yargs';
 
 import { GenerateTypesFromFileArguments } from '../../workflows/generate-types-from-file';
 
+type Argv = { i: string; o: string; t: boolean };
+
 export const validateArguments = (): GenerateTypesFromFileArguments => {
   const argv = yargs(hideBin(process.argv))
     .scriptName('generateTypesFromFile')
-    .usage(chalk.blueBright('$0 -i [swaggerJsonPath] -o [outputPath]'))
+    .usage(chalk.blueBright('$0 -i [swaggerJsonPath] -o [outputPath] -t'))
     .epilogue('Generates api types from a swagger json file')
     .example('$0 -i ./specs/swagger.json -o ./src/api/types', '')
     .describe('i', chalk.cyanBright('The path to the swagger json file'))
     .describe('o', chalk.cyanBright('Where to write the generated api types'))
-    .demandOption(['i', 'o']).argv as { i: string; o: string };
+    .describe(
+      't',
+      chalk.cyanBright(
+        'Whether types should be exported with the `export type ...` syntax (importsNotUsedAsValues option)',
+      ),
+    )
+    .default('t', false)
+    .boolean('t')
+    .demandOption(['i', 'o']).argv as Argv;
 
-  return { inputPath: argv.i, outputPath: argv.o };
+  return {
+    inputPath: argv.i,
+    outputPath: argv.o,
+    importsNotUsedAsValues: argv.t,
+  };
 };

--- a/src/cli/args/validate-url-arguments.test.ts
+++ b/src/cli/args/validate-url-arguments.test.ts
@@ -42,12 +42,49 @@ describe('validateUrlArguments function', () => {
     );
   });
 
-  it('should return args', async () => {
+  it('should return args and default values', async () => {
     const args = runCommand(validateArgumentsPath, '-u', url, '-o', outputPath);
 
     expect(args).toStrictEqual({
       swaggerJsonUrl: url,
       outputPath,
+      importsNotUsedAsValues: false,
     });
+  });
+
+  it('should return true when passing -t option', async () => {
+    const args = runCommand(
+      validateArgumentsPath,
+      validateArgumentsPath,
+      '-u',
+      url,
+      '-o',
+      outputPath,
+      '-t',
+    );
+
+    expect(args).toEqual(
+      expect.objectContaining({
+        importsNotUsedAsValues: true,
+      }),
+    );
+  });
+
+  it('should return true when giving an arbitrary valut to -t option', async () => {
+    const args = runCommand(
+      validateArgumentsPath,
+      '-u',
+      url,
+      '-o',
+      outputPath,
+      '-t',
+      'yolo',
+    );
+
+    expect(args).toEqual(
+      expect.objectContaining({
+        importsNotUsedAsValues: true,
+      }),
+    );
   });
 });

--- a/src/cli/args/validate-url-arguments.ts
+++ b/src/cli/args/validate-url-arguments.ts
@@ -5,6 +5,8 @@ import yargs from 'yargs/yargs';
 
 import { GenerateTypesFromUrlArguments } from '../../workflows/generate-types-from-url';
 
+type Argv = { u: string; o: string; t: boolean };
+
 export const validateArguments = (): GenerateTypesFromUrlArguments => {
   dotenv.config({ silent: true });
 
@@ -18,6 +20,14 @@ export const validateArguments = (): GenerateTypesFromUrlArguments => {
     )
     .describe('u', chalk.cyanBright('Swagger json url'))
     .describe('o', chalk.cyanBright('Where to write the generated api types'))
+    .describe(
+      't',
+      chalk.cyanBright(
+        'Whether types should be exported with the `export type ...` syntax (importsNotUsedAsValues option)',
+      ),
+    )
+    .default('t', false)
+    .boolean('t')
     .check((args) => {
       const urlRegex = /^(https?|chrome):\/\/[^\s$.?#].[^\s]*$/;
       if (!urlRegex.test(args.u as string)) {
@@ -28,7 +38,11 @@ export const validateArguments = (): GenerateTypesFromUrlArguments => {
 
       return true;
     })
-    .demandOption(['u', 'o']).argv as { u: string; o: string };
+    .demandOption(['u', 'o']).argv as Argv;
 
-  return { swaggerJsonUrl: argv.u, outputPath: argv.o };
+  return {
+    swaggerJsonUrl: argv.u,
+    outputPath: argv.o,
+    importsNotUsedAsValues: argv.t,
+  };
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,15 @@
 import { fetchSwaggerJson } from './logic/fetching/fetch-swagger-json-file';
+import { readSwaggerJsonFile } from './logic/fetching/read-swagger-json-file';
 import { generateTypesDefinitions } from './logic/ts-generation/generate-types-definitions';
 import { validateSchema } from './logic/validation/validate-schema';
 import { InputSwaggerJson } from './types/input-swagger-json.interface';
 import { ValidatedOpenaApiSchema } from './types/swagger-schema.interfaces';
 
-export { fetchSwaggerJson, validateSchema, generateTypesDefinitions };
+export {
+  readSwaggerJsonFile,
+  fetchSwaggerJson,
+  validateSchema,
+  generateTypesDefinitions,
+};
 
 export type { InputSwaggerJson, ValidatedOpenaApiSchema };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,28 @@
-import { fetchSwaggerJson } from './logic/fetching/fetch-swagger-json-file';
-import { readSwaggerJsonFile } from './logic/fetching/read-swagger-json-file';
 import { generateTypesDefinitions } from './logic/ts-generation/generate-types-definitions';
 import { validateSchema } from './logic/validation/validate-schema';
+import { GenerationResult } from './types/generation-result.interface';
 import { InputSwaggerJson } from './types/input-swagger-json.interface';
 import { ValidatedOpenaApiSchema } from './types/swagger-schema.interfaces';
+import {
+  generateTypesFromFile,
+  GenerateTypesFromFileArguments,
+} from './workflows/generate-types-from-file';
+import {
+  generateTypesFromUrl,
+  GenerateTypesFromUrlArguments,
+} from './workflows/generate-types-from-url';
 
 export {
-  readSwaggerJsonFile,
-  fetchSwaggerJson,
+  generateTypesFromFile,
+  generateTypesFromUrl,
   validateSchema,
   generateTypesDefinitions,
 };
 
-export type { InputSwaggerJson, ValidatedOpenaApiSchema };
+export type {
+  InputSwaggerJson,
+  ValidatedOpenaApiSchema,
+  GenerateTypesFromUrlArguments,
+  GenerateTypesFromFileArguments,
+  GenerationResult,
+};

--- a/src/logic/ts-generation/generate-types-definitions.test.ts
+++ b/src/logic/ts-generation/generate-types-definitions.test.ts
@@ -34,7 +34,7 @@ describe('generateTypesDefinitions function', () => {
   beforeEach(() => jest.clearAllMocks());
 
   it('should generate all the types', async () => {
-    const result = await generateTypesDefinitions(outPath, json);
+    const result = await generateTypesDefinitions(outPath, json, false);
 
     expect(result).toStrictEqual({
       typesGenerated: true,
@@ -139,7 +139,7 @@ describe('generateTypesDefinitions function', () => {
   });
 
   it('should export one path variable by exposed endpoint', async () => {
-    await generateTypesDefinitions(outPath, json);
+    await generateTypesDefinitions(outPath, json, false);
 
     expect(writeFile).toHaveBeenCalledTimes(6);
 
@@ -153,7 +153,7 @@ describe('generateTypesDefinitions function', () => {
   });
 
   it('should import related types for each exposed endpoint', async () => {
-    await generateTypesDefinitions(outPath, json);
+    await generateTypesDefinitions(outPath, json, false);
 
     expect(writeFile).toHaveBeenCalledTimes(6);
 
@@ -165,10 +165,24 @@ describe('generateTypesDefinitions function', () => {
     expectWriteFileCallToContain(4, reExportingRegex);
   });
 
+  it('should use the import type syntax for imports', async () => {
+    await generateTypesDefinitions(outPath, json, true);
+
+    expect(writeFile).toHaveBeenCalledTimes(6);
+
+    const reExportingRegex = /import type { .* } from '.\/..\/api-types';\n\n/;
+    expectWriteFileCallToContain(0, reExportingRegex);
+    expectWriteFileCallToContain(1, reExportingRegex);
+    expectWriteFileCallToContain(2, reExportingRegex);
+    expectWriteFileCallToContain(3, reExportingRegex);
+    expectWriteFileCallToContain(4, reExportingRegex);
+  });
+
   it('should not include the api-types import', async () => {
     await generateTypesDefinitions(
       outPath,
       swaggerWithoutTypesJson as unknown as ValidatedOpenaApiSchema,
+      false,
     );
 
     expect(writeFile).toHaveBeenCalledTimes(1);
@@ -181,6 +195,7 @@ describe('generateTypesDefinitions function', () => {
     await generateTypesDefinitions(
       outPath,
       swaggerWithoutSuccessTypeJson as unknown as ValidatedOpenaApiSchema,
+      false,
     );
 
     expect(writeFile).toHaveBeenCalledTimes(1);
@@ -192,7 +207,7 @@ describe('generateTypesDefinitions function', () => {
   });
 
   it('should generate jsdoc for each endpoint', async () => {
-    await generateTypesDefinitions(outPath, json);
+    await generateTypesDefinitions(outPath, json, false);
 
     expect(writeFile).toHaveBeenCalledTimes(6);
 
@@ -206,7 +221,7 @@ describe('generateTypesDefinitions function', () => {
   });
 
   it('should export one type by response', async () => {
-    await generateTypesDefinitions(outPath, json);
+    await generateTypesDefinitions(outPath, json, false);
 
     expect(writeFile).toHaveBeenCalledTimes(6);
 
@@ -238,7 +253,7 @@ describe('generateTypesDefinitions function', () => {
   });
 
   it('should export the request body type if any', async () => {
-    await generateTypesDefinitions(outPath, json);
+    await generateTypesDefinitions(outPath, json, false);
 
     expect(writeFile).toHaveBeenCalledTimes(6);
 
@@ -247,7 +262,7 @@ describe('generateTypesDefinitions function', () => {
   });
 
   it('should generate valid typescript for types', async () => {
-    await generateTypesDefinitions(outPath, json);
+    await generateTypesDefinitions(outPath, json, false);
 
     expect(writeFile).toHaveBeenCalledTimes(6);
     const rawResult = mocked(writeFile).mock.calls[5][1];
@@ -259,6 +274,7 @@ describe('generateTypesDefinitions function', () => {
     await generateTypesDefinitions(
       outPath,
       swaggerJsonWithMissingRouteName as unknown as ValidatedOpenaApiSchema,
+      false,
     );
 
     expect(console.error).toHaveBeenCalledTimes(1);
@@ -266,10 +282,14 @@ describe('generateTypesDefinitions function', () => {
   });
 
   it('should not write anything', async () => {
-    const result = await generateTypesDefinitions(outPath, {
-      components: { schemas: {} },
-      paths: [],
-    });
+    const result = await generateTypesDefinitions(
+      outPath,
+      {
+        components: { schemas: {} },
+        paths: [],
+      },
+      false,
+    );
 
     expect(result).toStrictEqual({
       typesGenerated: false,

--- a/src/logic/ts-generation/generate-types-definitions.ts
+++ b/src/logic/ts-generation/generate-types-definitions.ts
@@ -47,10 +47,11 @@ export const generateTypesDefinitions = async (
     const doc = getJsDoc(id, verb, summary, description);
 
     endpointsCount++;
+    const maybeTypeKeyword = importsNotUsedAsValues ? 'type ' : '';
     const maybeImport =
       models.length === 0
         ? ''
-        : `import ${importsNotUsedAsValues ? 'type ' : ''}{ ${models.join(
+        : `import ${maybeTypeKeyword}{ ${models.join(
             ', ',
           )} } from './../api-types';\n\n`;
     await writeFile(

--- a/src/logic/ts-generation/generate-types-definitions.ts
+++ b/src/logic/ts-generation/generate-types-definitions.ts
@@ -15,6 +15,7 @@ import { getRouteOutputsExports } from './get-route-outputs-exports';
 export const generateTypesDefinitions = async (
   outPath: string,
   json: ValidatedOpenaApiSchema,
+  importsNotUsedAsValues: boolean,
 ): Promise<GenerationResult> => {
   const typesDefinition = getTypesDefinitions(json.components.schemas);
   const endpoints = getExposedEndpoints(json);
@@ -49,7 +50,9 @@ export const generateTypesDefinitions = async (
     const maybeImport =
       models.length === 0
         ? ''
-        : `import { ${models.join(', ')} } from './../api-types';\n\n`;
+        : `import ${importsNotUsedAsValues ? 'type ' : ''}{ ${models.join(
+            ', ',
+          )} } from './../api-types';\n\n`;
     await writeFile(
       `${controllerPath}/${routeName}.ts`,
       `/* eslint-disable */\n/* tslint:disable */\n\n${doc}\n\n${maybeImport}${routePath}\n\n${inputsExports}${outputExports}\n`,

--- a/src/workflows/generate-types-from-file.ts
+++ b/src/workflows/generate-types-from-file.ts
@@ -6,14 +6,16 @@ import { GenerationResult } from '../types/generation-result.interface';
 export type GenerateTypesFromFileArguments = {
   inputPath: string;
   outputPath: string;
+  importsNotUsedAsValues: boolean;
 };
 
 export const generateTypesFromFile = async ({
   inputPath,
   outputPath,
+  importsNotUsedAsValues,
 }: GenerateTypesFromFileArguments): Promise<GenerationResult> => {
   const data = await readSwaggerJsonFile(inputPath);
   const schema = await validateSchema(data);
 
-  return generateTypesDefinitions(outputPath, schema);
+  return generateTypesDefinitions(outputPath, schema, importsNotUsedAsValues);
 };

--- a/src/workflows/generate-types-from-url.ts
+++ b/src/workflows/generate-types-from-url.ts
@@ -6,14 +6,16 @@ import { GenerationResult } from '../types/generation-result.interface';
 export type GenerateTypesFromUrlArguments = {
   swaggerJsonUrl: string;
   outputPath: string;
+  importsNotUsedAsValues: boolean;
 };
 
 export const generateTypesFromUrl = async ({
   swaggerJsonUrl,
   outputPath,
+  importsNotUsedAsValues,
 }: GenerateTypesFromUrlArguments): Promise<GenerationResult> => {
   const data = await fetchSwaggerJson(swaggerJsonUrl);
   const schema = await validateSchema(data);
 
-  return generateTypesDefinitions(outputPath, schema);
+  return generateTypesDefinitions(outputPath, schema, importsNotUsedAsValues);
 };


### PR DESCRIPTION
Adding a `-t` option to generate valid imports for typescript codebases using the `importsNotUsedAsValues` typescript option.

